### PR TITLE
Fixed typo in ru

### DIFF
--- a/values-ru/strings.xml
+++ b/values-ru/strings.xml
@@ -99,7 +99,7 @@
     <string name="graphic_eq_preset_bass_reduction">Ослабить басс</string>
     <string name="graphic_eq_preset_treble_boost">Усилить ВЧ</string>
     <string name="graphic_eq_preset_treble_reduction">Ослабить ВЧ</string>
-    <string name="graphic_eq_preset_vocal_boost">Выровнить громкость</string>
+    <string name="graphic_eq_preset_vocal_boost">Выровнять громкость</string>
     <string name="graphic_eq_preset_m_shaped">M-образный</string>
     <string name="graphic_eq_preset_u_shaped">U-образный</string>
     <string name="graphic_eq_preset_v_shaped">V-образный</string>


### PR DESCRIPTION
Changed verb ending to more grammatically correct one. Source:
https://ru.wiktionary.org/wiki/%D0%B2%D1%8B%D1%80%D0%BE%D0%B2%D0%BD%D1%8F%D1%82%D1%8C