### PR TITLE
Update spanish translation

### DIFF
--- a/values-es/strings.xml
+++ b/values-es/strings.xml
@@ -2,21 +2,21 @@
 <resources>
     <string name="app_name">Wavelet</string>
     <string name="no_active_sessions">Aún no se han iniciado sesiones de música</string>
-    <string name="single_user_warning">Por favor, instale la aplicación como usuario del sistema</string>
-    <string name="warning_library_null">Wavelet no pudo inicializar efectos %s</string>
-    <string name="warning_no_browser">No se pudo abrir la página %s</string>
+    <string name="single_user_warning">Instala la aplicación como usuario del sistema</string>
+    <string name="warning_library_null">Wavelet no pudo crear los efectos %s</string>
+    <string name="warning_no_browser">No se pudo abrir la URL %s</string>
     <string name="warning_billing_service">Error %d: Servicio de cobro no disponible</string>
-    <string name="paid_feature">Desbloquear todas las características por %s</string>
+    <string name="paid_feature">Desbloquear todas las funciones por %s</string>
     <string name="unlock">Desbloquear</string>
 
-    <string name="purchase_dialog_title">Mejore su experiencia</string>
-    <string name="purchase_dialog_text">Su experiencia de audio podría ser aún mejor por %s</string>
-    <string name="purchase_dialog_refund">Google Play proporciona una <annotation url="refund">garantía de devolución de 48hs</annotation> para que pueda probar todas las funciones</string>
+    <string name="purchase_dialog_title">Mejora tu experiencia</string>
+    <string name="purchase_dialog_text">Tu experiencia de audio podría ser aún mejor por %s</string>
+    <string name="purchase_dialog_refund">Google Play proporciona una <annotation url="refund">garantía de devolución de 48 h</annotation> para que puedas probar todas las funciones</string>
     <string name="purchase_dialog_positive">Comprar ahora</string>
     <string name="purchase_dialog_negative">Quizás más tarde</string>
 
     <string name="restricted_warning_text">Wavelet no puede funcionar correctamente si el uso de batería se establece en \'restringido\'</string>
-    <string name="open_settings">Corregir</string>
+    <string name="open_settings">Solucionar</string>
 
     <!-- Settings -->
     <string name="wavelet_toggle">Wavelet activado/desactivado</string>
@@ -24,28 +24,28 @@
     <string name="settings_legacy_mode">Modo heredado</string>
     <string name="settings_dump_permission">Acceso DUMP</string>
     <string name="settings_notification_access">Acceso a notificaciones</string>
-    <string name="settings_permission_granted">Permitido</string>
-    <string name="settings_permission_denied">No permitido</string>
+    <string name="settings_permission_granted">Permiso otorgado</string>
+    <string name="settings_permission_denied">Permiso denegado</string>
     <string name="menu_help">Ayuda</string>
     <string name="settings_buffer_size">Tamaño de búfer</string>
-    <string name="clipping_over_latency">Preferir recortes a latencia</string>
-    <string name="latency_over_clipping">Preferir latencia a recortes</string>
+    <string name="clipping_over_latency">Preferir recorte a latencia</string>
+    <string name="latency_over_clipping">Preferir latencia a recorte</string>
     <string name="setting_enhanced_session_title">Detección de sesiones mejorada</string>
-    <string name="setting_enhanced_session_summary">Ambos permisos son requeridos</string>
+    <string name="setting_enhanced_session_summary">Se requieren ambos permisos</string>
 
     <!-- Foreground Service notification -->
-    <string name="service_channel_name">Servicio Wavelet</string>
-    <string name="service_description">Servicio Wavelet para mantener las mejoras de audio activas</string>
+    <string name="service_channel_name">Servicio de Wavelet</string>
+    <string name="service_description">Servicio de Wavelet para mantener las mejoras de audio activas</string>
     <string name="service_notification_text">Aplicaciones usando Wavelet:</string>
-    <string name="service_notification_text_default">Pulse para más opciones</string>
+    <string name="service_notification_text_default">Presiona para ver más opciones</string>
 
     <string name="device_unknown">Dispositivo desconocido</string>
     <string name="device_headphone">Auriculares</string>
     <string name="device_headset">Cascos</string>
-    <string name="device_speaker">Altavoz</string>
+    <string name="device_speaker">Altavoces</string>
     <string name="device_bluetooth">Bluetooth</string>
-    <string name="device_hearing_aid">Dispositivo para la audición</string>
-    <string name="device_usb">USB</string>
+    <string name="device_hearing_aid">Audífonos</string>
+    <string name="device_usb">Dispositivo USB</string>
     <string name="device_android_auto">Android Auto</string>
     <string name="device_chrome_os">Chrome OS</string>
 
@@ -54,56 +54,56 @@
     <string name="category_equalization">Ecualizador</string>
     <string name="auto_eq_title">AutoEq</string>
     <string name="auto_eq_dialog_title">Modelo de auriculares</string>
-    <string name="auto_eq_strength">Potencia de AutoEq</string>
+    <string name="auto_eq_strength">Intensidad de AutoEq</string>
     <string name="auto_eq_import">Importar</string>
-    <string name="auto_eq_file_import_success">%s importado</string>
-    <string name="auto_eq_file_import_fail">Error al importar %s</string>
-    <string name="auto_eq_remove_item">Remover elemento</string>
+    <string name="auto_eq_file_import_success">%s importado correctamente</string>
+    <string name="auto_eq_file_import_fail">No se pudo importar %s</string>
+    <string name="auto_eq_remove_item">Eliminar elemento</string>
     <string name="graphic_eq_title">Ecualizador gráfico</string>
-    <string name="graphic_eq_dialog_title">Cambiar configuración personalizada</string>
-    <string name="graphic_eq_presets">Preconfiguración</string>
-    <string name="equal_loudness_title">Igualdad de volumen</string>
+    <string name="graphic_eq_dialog_title">Sobrescribir configuración personal</string>
+    <string name="graphic_eq_presets">Configuraciones</string>
+    <string name="equal_loudness_title">Compensación de sonoridad</string>
     <string name="equal_loudness_threshold">Umbral de volumen</string>
 
     <string name="category_effects">Efectos</string>
-    <string name="bass_boost_title">Resaltar bajos</string>
-    <string name="bass_boost_strength">Potencia de bajos</string>
+    <string name="bass_boost_title">Aumento de graves</string>
+    <string name="bass_boost_strength">Intensidad de aumento</string>
     <string name="preset_reverb_title">Reverberación</string>
-    <string name="preset_reverb_preset">Preconfiguración</string>
+    <string name="preset_reverb_preset">Configuración</string>
     <string name="virtualizer_title">Virtualizador</string>
-    <string name="virtualizer_strength">Potencia de virtualización</string>
-    <string name="bass_tuner_title">Ajustar bajos</string>
-    <string name="bass_tuner_type">Tipo de implementación</string>
+    <string name="virtualizer_strength">Intensidad de virtualización</string>
+    <string name="bass_tuner_title">Afinador de graves</string>
+    <string name="bass_tuner_type">Tipo de graves</string>
     <string name="bass_tuner_type_natural">Natural</string>
-    <string name="bass_tuner_type_transient_compressor">Compresor transitorio</string>
-    <string name="bass_tuner_type_sustain_compressor">Compresor sostenido</string>
+    <string name="bass_tuner_type_transient_compressor">Compresor de transitorios</string>
+    <string name="bass_tuner_type_sustain_compressor">Compresor de sustain</string>
     <string name="bass_tuner_cutoff_frequency">Frecuencia de corte</string>
-    <string name="bass_tuner_post_gain">Post-ganancia</string>
+    <string name="bass_tuner_post_gain">Ganancia posterior</string>
 
     <string name="category_gain_control">Control de ganancia</string>
     <string name="limiter_title">Limitador</string>
     <string name="limiter_attack_time">Tiempo de ataque</string>
-    <string name="limiter_release_time">Tiempo de salida</string>
-    <string name="limiter_ratio">Radio</string>
+    <string name="limiter_release_time">Tiempo de liberación</string>
+    <string name="limiter_ratio">Relación</string>
     <string name="limiter_threshold">Umbral</string>
-    <string name="limiter_automatic_post_gain">Post-ganancia automática</string>
-    <string name="limiter_post_gain">Post-ganancia</string>
+    <string name="limiter_automatic_post_gain">Ganancia posterior automática</string>
+    <string name="limiter_post_gain">Ganancia posterior</string>
     <string name="channel_balance_title">Balance de canales</string>
     <string name="channel_balance_left_gain">Ganancia canal izquierdo</string>
     <string name="channel_balance_right_gain">Ganancia canal derecho</string>
 
     <string name="graphic_eq_preset_flat">Plano</string>
-    <string name="graphic_eq_preset_dark">Opaco</string>
+    <string name="graphic_eq_preset_dark">Oscuro</string>
     <string name="graphic_eq_preset_bright">Brillante</string>
-    <string name="graphic_eq_preset_bass_boost">Resaltar bajos</string>
-    <string name="graphic_eq_preset_bass_reduction">Reducir bajos</string>
-    <string name="graphic_eq_preset_treble_boost">Resaltar agudos</string>
-    <string name="graphic_eq_preset_treble_reduction">Reducir agudos</string>
-    <string name="graphic_eq_preset_vocal_boost">Resaltar vocales</string>
-    <string name="graphic_eq_preset_m_shaped">Figura \'M\'</string>
-    <string name="graphic_eq_preset_u_shaped">Figura \'U\'</string>
-    <string name="graphic_eq_preset_v_shaped">Figura \'V\'</string>
-    <string name="graphic_eq_preset_w_shaped">Figura \'W\'</string>
+    <string name="graphic_eq_preset_bass_boost">Aumento de graves</string>
+    <string name="graphic_eq_preset_bass_reduction">Reducción de graves</string>
+    <string name="graphic_eq_preset_treble_boost">Aumento de agudos</string>
+    <string name="graphic_eq_preset_treble_reduction">Reducción de agudos</string>
+    <string name="graphic_eq_preset_vocal_boost">Aumento vocal</string>
+    <string name="graphic_eq_preset_m_shaped">Forma de M</string>
+    <string name="graphic_eq_preset_u_shaped">Forma de U</string>
+    <string name="graphic_eq_preset_v_shaped">Forma de V</string>
+    <string name="graphic_eq_preset_w_shaped">Forma de W</string>
     <string name="graphic_eq_preset_personal">Personalizada</string>
 
     <string name="preset_reverb_small_room">Habitación pequeña</string>


### PR DESCRIPTION
I have checked the translation again from scratch and corrected some things. Now the application addresses the user in an informal way (like in [AOSP](https://translations.zhanghai.me/) and Google apps). Several translations were changed to the ones used in AOSP, and inconsistencies were corrected. I also fixed some strings that had been simplified, now the original meaning is better maintained. Several technical terms were better interpreted into spanish.